### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/near/near-sandbox-rs/compare/v0.1.0...v0.1.1) - 2025-07-17
+
+### Other
+
+- Renamed `near-sandbox-utils` references to `near-sandbox` in README.md
+
 ## [0.15.0](https://github.com/near/near-sandbox/compare/v0.14.0...v0.15.0) - 2025-05-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "near-sandbox"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "binary-install",
  "bs58 0.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/near/near-sandbox-rs/compare/v0.1.0...v0.1.1) - 2025-07-17

### Other

- Renamed `near-sandbox-utils` references to `near-sandbox` in README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).