### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/near/near-sandbox-rs/compare/v0.1.0...v0.2.0) - 2025-07-18
+
+### Fixed
+
+- `generate` feature didn't compile ([#10](https://github.com/near/near-sandbox-rs/pull/10))
+
+### Other
+
+- removing unneeded legacy code ([#7](https://github.com/near/near-sandbox-rs/pull/7))
+- Updated one left-over reference to the old near-sandbox-utils in README.md
+- Renamed `near-sandbox-utils` references to `near-sandbox` in README.md
+
 ## [0.15.0](https://github.com/near/near-sandbox/compare/v0.14.0...v0.15.0) - 2025-05-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "near-sandbox"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "binary-install",
  "bs58 0.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `near-sandbox` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum near_sandbox::high_level::TcpError, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/mod.rs:20
  enum near_sandbox::high_level::config::SandboxConfigError, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:31
  enum near_sandbox::high_level::SandboxConfigError, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:31
  enum near_sandbox::SandboxError, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:20

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function near_sandbox::run_with_version, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:240
  function near_sandbox::ensure_sandbox_bin_with_version, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:217
  function near_sandbox::run, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:199
  function near_sandbox::sync::run, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/sync.rs:15
  function near_sandbox::ensure_sandbox_bin, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:186
  function near_sandbox::sync::run_with_options, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/sync.rs:6
  function near_sandbox::install, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:161
  function near_sandbox::high_level::config::set_sandbox_genesis, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:371
  function near_sandbox::init_with_version, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:263
  function near_sandbox::run_with_options_with_version, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:228
  function near_sandbox::init, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:213
  function near_sandbox::sync::init, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/sync.rs:32
  function near_sandbox::run_with_options, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:190
  function near_sandbox::install_with_version, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:130
  function near_sandbox::high_level::config::set_sandbox_genesis_with_config, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:376
  function near_sandbox::bin_path, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/lib.rs:105

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod near_sandbox::sync, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/sync.rs:1
  mod near_sandbox::high_level, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/mod.rs:1
  mod near_sandbox::high_level::config, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  DEFAULT_GENESIS_ACCOUNT in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:24
  DEFAULT_GENESIS_ACCOUNT_PUBLIC_KEY in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:26
  DEFAULT_GENESIS_ACCOUNT_BALANCE in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:28
  DEFAULT_GENESIS_ACCOUNT_PRIVATE_KEY in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:25

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct near_sandbox::high_level::Sandbox, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/mod.rs:97
  struct near_sandbox::high_level::config::GenesisAccount, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:93
  struct near_sandbox::high_level::GenesisAccount, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:93
  struct near_sandbox::high_level::config::SandboxConfig, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:175
  struct near_sandbox::high_level::SandboxConfig, previously in file /tmp/.tmpH6pLs1/near-sandbox/src/high_level/config.rs:175
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/near/near-sandbox-rs/compare/v0.1.0...v0.2.0) - 2025-07-18

### Fixed

- `generate` feature didn't compile ([#10](https://github.com/near/near-sandbox-rs/pull/10))

### Other

- removing unneeded legacy code ([#7](https://github.com/near/near-sandbox-rs/pull/7))
- Updated one left-over reference to the old near-sandbox-utils in README.md
- Renamed `near-sandbox-utils` references to `near-sandbox` in README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).