### PR TITLE
feat: add arm64 Linux target

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -35,6 +35,9 @@ const fn platform() -> Option<&'static str> {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     return Some("Linux-x86_64");
 
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    return Some("Linux-aarch64");
+
     // Darwin-x86_64 is not supported for some time now.
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     return None;
@@ -44,7 +47,8 @@ const fn platform() -> Option<&'static str> {
 
     #[cfg(all(
         not(target_os = "macos"),
-        not(all(target_os = "linux", target_arch = "x86_64"))
+        not(all(target_os = "linux", target_arch = "x86_64")),
+        not(all(target_os = "linux", target_arch = "aarch64"))
     ))]
     return None;
 }


### PR DESCRIPTION
Related Issue:
https://github.com/near/near-workspaces-rs/issues/429

I added the new target and tested it — everything runs well on ARM64 Linux. However, I noticed an interesting detail that is not mentioned in the README. Before I was able to run `cargo test` and execute the examples, I had to apply the following settings:

```bash
sudo sysctl -w net.core.rmem_max=8388608
sudo sysctl -w net.core.wmem_max=8388608
sudo sysctl -w "net.ipv4.tcp_rmem=4096 87380 8388608"
sudo sysctl -w "net.ipv4.tcp_wmem=4096 16384 8388608"
sudo sysctl -w net.ipv4.tcp_slow_start_after_idle=0
```

Without these parameters, I was getting errors when running both the tests and the examples.
