### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/near/near-sandbox-rs/compare/v0.2.2...v0.2.3) - 2025-11-30
+
+### Added
+
+- Enabled support for arm64 Linux target ([#31](https://github.com/near/near-sandbox-rs/pull/31))
+
 ## [0.2.2](https://github.com/near/near-sandbox-rs/compare/v0.2.1...v0.2.2) - 2025-11-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-sandbox-rs"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/near/near-sandbox-rs/compare/v0.2.2...v0.2.3) - 2025-11-30

### Added

- Enabled support for arm64 Linux target ([#31](https://github.com/near/near-sandbox-rs/pull/31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).