### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/near/near-sandbox-rs/compare/v0.3.0...v0.3.1) - 2025-12-02
+
+### Added
+
+- intall sandbox ([#36](https://github.com/near/near-sandbox-rs/pull/36))
+
 ## [0.3.0](https://github.com/near/near-sandbox-rs/compare/v0.2.3...v0.3.0) - 2025-12-02
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-sandbox-rs"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/near/near-sandbox-rs/compare/v0.3.0...v0.3.1) - 2025-12-02

### Added

- intall sandbox ([#36](https://github.com/near/near-sandbox-rs/pull/36))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).