### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/near/near-sandbox-rs/compare/v0.3.1...v0.3.2) - 2025-12-04
+
+### Other
+
+- update nearcore version to 2.10.1 ([#38](https://github.com/near/near-sandbox-rs/pull/38))
+
 ## [0.3.1](https://github.com/near/near-sandbox-rs/compare/v0.3.0...v0.3.1) - 2025-12-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-sandbox-rs"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/near/near-sandbox-rs/compare/v0.3.1...v0.3.2) - 2025-12-04

### Other

- update nearcore version to 2.10.1 ([#38](https://github.com/near/near-sandbox-rs/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).