### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0](https://github.com/near/near-sandbox-rs/compare/v0.3.2...v0.4.0) - 2025-12-12
+## [0.3.3](https://github.com/near/near-sandbox-rs/compare/v0.3.2...v0.3.3) - 2025-12-12
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.4.0"
+version = "0.3.3"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-sandbox-rs"


### PR DESCRIPTION

## 🤖 New release

* `near-sandbox`: 0.3.2 -> 0.3.3 (⚠ API breaking changes)

### ⚠ `near-sandbox` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SandboxConfig.port_transfer_retries in /tmp/.tmpoD72eJ/near-sandbox-rs/src/config.rs:190
  field SandboxConfig.port_transfer_retries in /tmp/.tmpoD72eJ/near-sandbox-rs/src/config.rs:190

--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum TcpError in /tmp/.tmpoD72eJ/near-sandbox-rs/src/error_kind.rs:60

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant SandboxError:ShutdownError in /tmp/.tmpoD72eJ/near-sandbox-rs/src/error_kind.rs:16
  variant SandboxError:SandboxStartupRetriesExhausted in /tmp/.tmpoD72eJ/near-sandbox-rs/src/error_kind.rs:22
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/near/near-sandbox-rs/compare/v0.3.2...v0.3.3) - 2025-12-12

### Fixed

- Improved available port selection during sandbox startup, so you should not see "port is already in use" anymore ([#40](https://github.com/near/near-sandbox-rs/pull/40))

### Other

- Update nearcore version to 2.10.2 ([#41](https://github.com/near/near-sandbox-rs/pull/41))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).