### PR TITLE
fix: kill `near-sandbox` process on drop

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -77,6 +77,7 @@ pub fn run_neard_with_port_guards(
         .args(options)
         .envs(log_vars())
         .stderr(stderr.unwrap_or(Stdio::inherit()))
+        .kill_on_drop(true)
         .spawn()
         .map_err(SandboxError::RuntimeError)
 }


### PR DESCRIPTION
This PR tells tokio to make its best effort to kill child `near-sandbox` process when `Sandbox` is dropped