### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/near/near-sandbox-rs/compare/v0.3.3...v0.3.4) - 2025-12-13
+
+### Fixed
+
+- kill near-sandbox process on drop ([#44](https://github.com/near/near-sandbox-rs/pull/44))
+
 ## [0.3.3](https://github.com/near/near-sandbox-rs/compare/v0.3.2...v0.3.3) - 2025-12-12
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-sandbox-rs"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.3 -> 0.3.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.4](https://github.com/near/near-sandbox-rs/compare/v0.3.3...v0.3.4) - 2025-12-13

### Fixed

- kill near-sandbox process on drop ([#44](https://github.com/near/near-sandbox-rs/pull/44))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).