### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/near/near-sandbox-rs/compare/v0.3.4...v0.3.5) - 2026-01-16
+
+### Other
+
+- Update nearcore version to 2.10.4 ([#50](https://github.com/near/near-sandbox-rs/pull/50))
+- added DevEx to CODEOWNERS ([#48](https://github.com/near/near-sandbox-rs/pull/48))
+- Update nearcore version to 2.10.3 ([#46](https://github.com/near/near-sandbox-rs/pull/46))
+
 ## [0.3.4](https://github.com/near/near-sandbox-rs/compare/v0.3.3...v0.3.4) - 2025-12-13
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-sandbox-rs"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.4 -> 0.3.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.5](https://github.com/near/near-sandbox-rs/compare/v0.3.4...v0.3.5) - 2026-01-16

### Other

- Update nearcore version to 2.10.4 ([#50](https://github.com/near/near-sandbox-rs/pull/50))
- added DevEx to CODEOWNERS ([#48](https://github.com/near/near-sandbox-rs/pull/48))
- Update nearcore version to 2.10.3 ([#46](https://github.com/near/near-sandbox-rs/pull/46))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).