### PR TITLE
chore: release v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9](https://github.com/near/near-sandbox-rs/compare/v0.3.8...v0.3.9) - 2026-04-01
+
+### Other
+
+- add fast_forward height mismatch regression test ([#54](https://github.com/near/near-sandbox-rs/pull/54))
+- Update nearcore version to 2.11.0 ([#69](https://github.com/near/near-sandbox-rs/pull/69))
+
 ## [0.3.8](https://github.com/near/near-sandbox-rs/compare/v0.3.7...v0.3.8) - 2026-03-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.8 -> 0.3.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.9](https://github.com/near/near-sandbox-rs/compare/v0.3.8...v0.3.9) - 2026-04-01

### Other

- add fast_forward height mismatch regression test ([#54](https://github.com/near/near-sandbox-rs/pull/54))
- Update nearcore version to 2.11.0 ([#69](https://github.com/near/near-sandbox-rs/pull/69))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).