### PR TITLE
chore: release v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10](https://github.com/near/near-sandbox-rs/compare/v0.3.9...v0.3.10) - 2026-04-21
+
+### Other
+
+- Update nearcore version to 2.11.1 ([#71](https://github.com/near/near-sandbox-rs/pull/71))
+
 ## [0.3.9](https://github.com/near/near-sandbox-rs/compare/v0.3.8...v0.3.9) - 2026-04-01
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.9 -> 0.3.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.10](https://github.com/near/near-sandbox-rs/compare/v0.3.9...v0.3.10) - 2026-04-21

### Other

- Update nearcore version to 2.11.1 ([#71](https://github.com/near/near-sandbox-rs/pull/71))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).