### PR TITLE
feat: update nearcore version to 2.12.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,5 @@ pub use config::{random_account_id, random_key_pair};
 
 // The current version of the sandbox node we want to point to.
 // Should be updated to the latest release of nearcore.
-// Currently pointing to nearcore@v2.11.1 released on April 21, 2026
-pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "2.11.1";
+// Currently pointing to nearcore@v2.12.0 (protocol 84) released on June 3, 2026
+pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "2.12.0";


### PR DESCRIPTION
nearcore 2.12.0 (protocol 84) is now live on mainnet, so the default sandbox should track it. The 2.12.0 tarball is published on S3 and downloads/runs fine.

- [Release Notes](https://github.com/near/nearcore/releases/tag/2.12.0)