### PR TITLE
chore: release v0.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11](https://github.com/near/near-sandbox-rs/compare/v0.3.10...v0.3.11) - 2026-06-03
+
+### Other
+
+- update nearcore version to 2.12.0 ([#74](https://github.com/near/near-sandbox-rs/pull/74))
+
 ## [0.3.10](https://github.com/near/near-sandbox-rs/compare/v0.3.9...v0.3.10) - 2026-04-21
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2024"
 rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release

* `near-sandbox`: 0.3.10 -> 0.3.11

Publishes the `DEFAULT_NEAR_SANDBOX_VERSION = "2.12.0"` default from #74 as a new patch release so it becomes the published default on crates.io.

### Changelog

#### [0.3.11](https://github.com/near/near-sandbox-rs/compare/v0.3.10...v0.3.11) - 2026-06-03

##### Other

- update nearcore version to 2.12.0 ([#74](https://github.com/near/near-sandbox-rs/pull/74))

---
Manually authored to mirror the release-plz "chore: release" PR. release-plz did not auto-open it because the `v0.3.10` tag points at the #74 HEAD commit (the April 0.3.10 release-plz run was cancelled, so 0.3.10 was first published today from the #74 commit and already ships 2.12.0). This PR bumps the version so release-plz's `release` job publishes 0.3.11.