### PR TITLE
ci: use nearprotocol-ci bot token for release-plz

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
+          token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
 
       - name: Install libudev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libsystemd-dev
@@ -154,5 +154,5 @@ jobs:
         uses: release-plz/action@v0.5
         env:
           # https://release-plz.ieni.dev/docs/github/trigger
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Switches the release-plz job to use the nearprotocol-ci bot token (`NEARPROTOCOL_CI_PR_ACCESS`) instead of `RELEASE_PLZ_GITHUB_TOKEN`, which is currently a personal PAT.

Right now release PRs get authored by my personal account, so I can't approve my own release PRs (code-owner review is required). Using the shared bot token means release PRs are authored by nearprotocol-ci instead, matching how near-sdk-rs and near-cli-rs already do it.

Updates both the checkout `token` and the release-plz `GITHUB_TOKEN` env.