### PR TITLE
chore: release v0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.12](https://github.com/near/near-sandbox-rs/compare/v0.3.11...v0.3.12) - 2026-07-02
+## [0.3.12-rc.1](https://github.com/near/near-sandbox-rs/compare/v0.3.11...v0.3.12-rc.1) - 2026-07-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12](https://github.com/near/near-sandbox-rs/compare/v0.3.11...v0.3.12) - 2026-07-02
+
+### Added
+
+- default sandbox to 2.13.0-rc.2 (protocol v85) ([#78](https://github.com/near/near-sandbox-rs/pull/78))
+
+### Other
+
+- use nearprotocol-ci bot token for release-plz ([#76](https://github.com/near/near-sandbox-rs/pull/76))
+
 ## [0.3.11](https://github.com/near/near-sandbox-rs/compare/v0.3.10...v0.3.11) - 2026-06-03
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.12"
+version = "0.3.12-rc.1"
 edition = "2024"
 rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2024"
 rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.11 -> 0.3.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.12](https://github.com/near/near-sandbox-rs/compare/v0.3.11...v0.3.12) - 2026-07-02

### Added

- default sandbox to 2.13.0-rc.2 (protocol v85) ([#78](https://github.com/near/near-sandbox-rs/pull/78))

### Other

- use nearprotocol-ci bot token for release-plz ([#76](https://github.com/near/near-sandbox-rs/pull/76))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).