### PR TITLE
feat: default sandbox to 2.13.0-rc.2 (protocol v85)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,5 @@ pub use config::{random_account_id, random_key_pair};
 
 // The current version of the sandbox node we want to point to.
 // Should be updated to the latest release of nearcore.
-// Currently pointing to nearcore@v2.12.0 (protocol 84) released on June 3, 2026
-pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "2.12.0";
+// Currently pointing to nearcore@v2.13.0-rc.2 (protocol 85) released on June 26, 2026
+pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "2.13.0-rc.2";


### PR DESCRIPTION
Bumps `DEFAULT_NEAR_SANDBOX_VERSION` from `2.12.0` to `2.13.0-rc.2` so downstream `near_workspaces::sandbox()` defaults to a protocol-v85 node.

- Binary confirmed fetchable from S3 (`.../nearcore/Linux-x86_64/2.13.0-rc.2/near-sandbox.tar.gz`, HTTP 200).
- fmt/clippy/build green; integration + patch-state tests pass against the live 2.13.0-rc.2 node.

Crate version left untouched (release-plz handles it on the release PR).