### PR TITLE
chore: release 0.3.12 + default to nearcore 2.13.0 sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.12-rc.1](https://github.com/near/near-sandbox-rs/compare/v0.3.11...v0.3.12-rc.1) - 2026-07-02
+## [0.3.12](https://github.com/near/near-sandbox-rs/compare/v0.3.11...v0.3.12) - 2026-07-09
 
 ### Added
 
-- default sandbox to 2.13.0-rc.2 (protocol v85) ([#78](https://github.com/near/near-sandbox-rs/pull/78))
+- default sandbox to nearcore 2.13.0 (protocol 86) ([#78](https://github.com/near/near-sandbox-rs/pull/78), [#80](https://github.com/near/near-sandbox-rs/pull/80))
 
 ### Other
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.12-rc.1"
+version = "0.3.12"
 edition = "2024"
 rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,5 @@ pub use config::{random_account_id, random_key_pair};
 
 // The current version of the sandbox node we want to point to.
 // Should be updated to the latest release of nearcore.
-// Currently pointing to nearcore@v2.13.0 (protocol 85) released on July 9, 2026
+// Currently pointing to nearcore@v2.13.0 (protocol 86) released on July 9, 2026
 pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "2.13.0";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,5 @@ pub use config::{random_account_id, random_key_pair};
 
 // The current version of the sandbox node we want to point to.
 // Should be updated to the latest release of nearcore.
-// Currently pointing to nearcore@v2.13.0-rc.2 (protocol 85) released on June 26, 2026
-pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "2.13.0-rc.2";
+// Currently pointing to nearcore@v2.13.0 (protocol 85) released on July 9, 2026
+pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "2.13.0";


### PR DESCRIPTION
nearcore 2.13.0 stable is out. This bumps the default sandbox binary from `2.13.0-rc.2` to `2.13.0` (protocol v85) and releases `near-sandbox` 0.3.12 (from 0.3.12-rc.1), so downstream `sandbox()` uses a stable v85 binary by default.

- `DEFAULT_NEAR_SANDBOX_VERSION`: `2.13.0-rc.2` -> `2.13.0`
- crate version: `0.3.12-rc.1` -> `0.3.12`