### PR TITLE
chore: release v0.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.13](https://github.com/near/near-sandbox-rs/compare/v0.3.12...v0.3.13) - 2026-07-20
+
+### Other
+
+- update nearcore version to 2.13.1 ([#81](https://github.com/near/near-sandbox-rs/pull/81))
+
 ## [0.3.12](https://github.com/near/near-sandbox-rs/compare/v0.3.11...v0.3.12) - 2026-07-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2024"
 rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.12 -> 0.3.13 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.13](https://github.com/near/near-sandbox-rs/compare/v0.3.12...v0.3.13) - 2026-07-20

### Other

- update nearcore version to 2.13.1 ([#81](https://github.com/near/near-sandbox-rs/pull/81))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).