### PR TITLE
chore: release v0.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.14](https://github.com/near/near-sandbox-rs/compare/v0.3.13...v0.3.14) - 2026-07-28
+
+### Other
+
+- Update nearcore version to 2.13.2 ([#88](https://github.com/near/near-sandbox-rs/pull/88))
+
 ## [0.3.13](https://github.com/near/near-sandbox-rs/compare/v0.3.12...v0.3.13) - 2026-07-20
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2024"
 rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.13 -> 0.3.14 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.14](https://github.com/near/near-sandbox-rs/compare/v0.3.13...v0.3.14) - 2026-07-28

### Other

- Update nearcore version to 2.13.2 ([#88](https://github.com/near/near-sandbox-rs/pull/88))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).