### PR TITLE
ci: update runners and use nearprotocol-ci for PRs

### DIFF
--- a/.github/workflows/check-nearcore-release.yml
+++ b/.github/workflows/check-nearcore-release.yml
@@ -54,7 +54,7 @@ jobs:
         if: steps.check-changes.outputs.update_needed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
+          token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
           add-paths: |
             src/lib.rs
           commit-message: "Update nearcore version to ${{ steps.latest-version.outputs.latest_version }}"

--- a/.github/workflows/check-nearcore-release.yml
+++ b/.github/workflows/check-nearcore-release.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: "18"
+          node-version: "24"
 
       - name: Run nearcore update script
         run: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check-changes.outputs.update_needed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
           add-paths: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install libudev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libsystemd-dev
@@ -52,7 +52,7 @@ jobs:
         os: [ubuntu-24.04, macos-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install libudev-dev (Linux only)
         if: runner.os == 'Linux'
@@ -82,7 +82,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install libudev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libsystemd-dev
@@ -110,7 +110,7 @@ jobs:
     needs: [check, test-platforms, check-doc]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install libudev (Linux only)
         if: runner.os == 'Linux'
@@ -139,7 +139,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}


### PR DESCRIPTION
## Pre-flight checklist

- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec

## Motivation

CI job for checking nearcore releases is broken bc of PR access + node@v20 was deprecated.

## Test Plan

CI passes and check-nearcore-release runs fine post-merge.
