### PR TITLE
chore: release v0.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.15](https://github.com/near/near-sandbox-rs/compare/v0.3.14...v0.3.15) - 2026-08-05
+
+### Other
+
+- Update nearcore version to 2.13.3 ([#91](https://github.com/near/near-sandbox-rs/pull/91))
+- update runners and use nearprotocol-ci for PRs ([#90](https://github.com/near/near-sandbox-rs/pull/90))
+
 ## [0.3.14](https://github.com/near/near-sandbox-rs/compare/v0.3.13...v0.3.14) - 2026-07-28
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2024"
 rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox`: 0.3.14 -> 0.3.15 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.15](https://github.com/near/near-sandbox-rs/compare/v0.3.14...v0.3.15) - 2026-08-05

### Other

- Update nearcore version to 2.13.3 ([#91](https://github.com/near/near-sandbox-rs/pull/91))
- update runners and use nearprotocol-ci for PRs ([#90](https://github.com/near/near-sandbox-rs/pull/90))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).